### PR TITLE
makefile: invoke customized formatter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ alldoc:
 
 .PHONY: fmt format
 fmt format:
-	@./tock/tools/run_cargo_fmt.sh
+	@./tools/run_cargo_fmt.sh
 
 .PHONY: list list-boards list-platforms
 list list-boards list-platforms:


### PR DESCRIPTION
### Pull Request Overview

This PR fixes the command `make format` which did not invoke the customized formatter tool.


### Testing Strategy

\-


### TODO or Help Wanted

\-


### Formatting

- ~[ ] `make format` has been run.~