### PR TITLE
github: add contribution guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing to Tock
+
+Thank you for your interest in contributing to Tock! Take a look at the
+[official contribution guidelines][contributing] to see how you can contribute.
+
+If you have questions, please make a post on the [mailing list][listserv] or
+hop on [#tock][irc].
+
+## What Goes Where?
+
+This repository contains all parts related to the support of STM32. The kernel
+as well as the userland examples and libraries are part of the
+[main repository][main].
+
+[main]: https://github.com/helena-project/tock
+[contributing]: https://github.com/helena-project/tock/blob/master/.github/CONTRIBUTING.md
+[irc]: https://kiwiirc.com/client/irc.freenode.net/tock
+[listserv]: https://groups.google.com/forum/#!forum/tock-dev

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+### Pull Request Overview
+
+This pull request adds/changes/fixes...
+
+
+### Testing Strategy
+
+This pull request was tested by...
+
+
+### TODO or Help Wanted
+
+This pull request still needs...
+
+
+### Formatting
+
+- [ ] `make format` has been run.


### PR DESCRIPTION
### Pull Request Overview

This patch adds the templates to guideline contributions to this repository. They have been adapted from the [main repository](https://github.com/helena-project/tock/tree/4a6b3786a8a9ebc181c2bb298157f63302e7bf8d/.github).

### Testing Strategy

\-


### TODO or Help Wanted

\-


### Formatting

- ~[ ] `make format` has been run.~
